### PR TITLE
Disable ethereum-multicall's `tryAggregate`

### DIFF
--- a/src/redux/balanceFetcher.ts
+++ b/src/redux/balanceFetcher.ts
@@ -60,7 +60,7 @@ const createFetching = (
 
         const multicall = new Multicall({
           ethersProvider: framework.settings.provider,
-          tryAggregate: true,
+          tryAggregate: false,
           multicallCustomContractAddress: multicallContractAddress,
         });
 


### PR DESCRIPTION
Why?
Seeing a new error occasionally pop up on Sentry that originates from ethereum-multicall: https://sentry.io/organizations/superfluid-finance/issues/3242418142/?project=6176225#tags

I'm unable to reproduce it on demand.

```
Error

data out-of-bounds (length=0, offset=32, code=BUFFER_OVERRUN, version=abi/5.6.1)
```

Found a weak link to the exception from this issue: 
https://github.com/joshstevens19/ethereum-multicall/issues/31

I don't think it quite describes the same thing but has the same error originate from `tryAggregate`. I'm going turn this feature off for now as it's not critical anyways and monitor whether the errors still keep appearing.