### PR TITLE
Fix hydration errors appearing on "/protocol"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "graphql": "^16.3.0",
     "graphql-ws": "^5.8.2",
     "lodash": "^4.17.21",
-    "next": "^12.1.7-canary.6",
+    "next": "^12.1.7-canary.23",
     "next-redux-cookie-wrapper": "^2.1.2",
     "next-redux-wrapper": "^7.0.5",
     "react": "^18.0.0",

--- a/src/pages/protocol.tsx
+++ b/src/pages/protocol.tsx
@@ -38,33 +38,36 @@ const AddressListItem: FC<AddressListItemProps> = ({
     <ListItemText
       data-cy={dataCy}
       primary={title}
-      secondary={
-        <Stack
-          direction="row"
-          alignItems="center"
-          sx={{ fontFamily: "Roboto Mono" }}
-        >
-          {address || "-"}
-          {address && (
-            <Stack direction="row" alignItems="center" gap={1}>
-              <CopyClipboard
-                copyText={address}
-                IconProps={{ sx: { fontSize: "16px" } }}
-              />
-              <Tooltip title="View on blockchain Explorer">
-                <Link
-                  href={network.getLinkForAddress(address)}
-                  target="_blank"
-                  sx={{ color: "inherit" }}
-                >
-                  <OpenInNewIcon sx={{ fontSize: "16px", display: "block" }} />
-                </Link>
-              </Tooltip>
-            </Stack>
-          )}
-        </Stack>
-      }
-    />
+      secondary={<Stack
+        component="span"
+        direction="row"
+        alignItems="center"
+        sx={{ fontFamily: "Roboto Mono" }}
+      >
+        {address || "-"}
+        {address && (
+          <Stack
+            component="span"
+            direction="row"
+            alignItems="center"
+            gap={1}
+          >
+            <CopyClipboard
+              copyText={address}
+              IconProps={{ sx: { fontSize: "16px" } }} />
+            <Tooltip title="View on blockchain Explorer">
+              <Link
+                // href={network.getLinkForAddress(address)}
+                target="_blank"
+                sx={{ color: "inherit" }}
+              >
+                <OpenInNewIcon
+                  sx={{ fontSize: "16px", display: "block" }} />
+              </Link>
+            </Tooltip>
+          </Stack>
+        )}
+      </Stack>} />
   </ListItem>
 );
 
@@ -215,7 +218,11 @@ const Protocol: FC = () => {
 
             <Card>
               <List
-                sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", pb: 2 }}
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  pb: 2,
+                }}
               >
                 <AddressListItem
                   dataCy={"resolver-address"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
   resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz#c15791112db68dd9315d329d652b7e797f737655"
   integrity sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==
 
-"@next/env@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.7-canary.16.tgz#10853c760a32358cf32e00a78107464f4eddd897"
-  integrity sha512-AXQXBrXMpf2KqqTcvXvvpJY+qG9tMyAMWyzXrkb02efbufSxeVskY4Y2EACyfarPC95+IycgDFrs8BCDRBDOBA==
+"@next/env@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.7-canary.23.tgz#bf6527bd24448449432ba6451ec603f0a81049a2"
+  integrity sha512-EKVoeIrvYrTK4xOlIIP3EMXZAltVN8QmJ6G8f/Oiuoyy+KdKyeHQRlOyxqFzxLwTgzDLnmm1gCcmvAlf9A10hQ==
 
 "@next/eslint-plugin-next@12.1.6":
   version "12.1.6"
@@ -1737,70 +1737,70 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-android-arm-eabi@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.16.tgz#b205fd6f8eb48639630c79e0eb7ebc407ce89856"
-  integrity sha512-ywssG0j6Uld9I9l+7Yapd0chncxTOqowALHEije+Q1CfRbZwOfGlAXctz4jkgfqw5A20i0ETvXA3HeauDKHNQg==
+"@next/swc-android-arm-eabi@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.23.tgz#6cdd178a6b8d31a1624a8e132fd2a584b219edab"
+  integrity sha512-OSz3g6p6c/U1t7Ve6fzP4zn32I6JJNcgWGemYRm7MFx05lu0YhVnRNGPzN2OEtAiF4WBok0r79sY+BOvvpDcBQ==
 
-"@next/swc-android-arm64@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.16.tgz#c4faedc9aa08f0edb78d54de05b0969d6c98c68f"
-  integrity sha512-qfB6M/SyfxabD+UshiAGzwB3qBDHljgLfAcxoir5UWjVdGk7zp2zFcL93MEz/o1gc2QLjk0CTppTURXq2bVdoQ==
+"@next/swc-android-arm64@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.23.tgz#536c00e2cdf330e00c174c25d0bd4673ac8b9183"
+  integrity sha512-WuS/4e8+PE/0l6EHl5cUNN4JDgYaoDEmD80sMiU+vzISMgArnJAOm/u/1hzhww5O5w7zdieLXTnOJo0nd1LRNg==
 
-"@next/swc-darwin-arm64@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.16.tgz#8061a43bf14fdbddeaf3e134d5514365c21752f8"
-  integrity sha512-m2xRcT6Vc9g7GWJB1wEEg/AYnf1dlEXYKb8SVsY82BTF2zxgQCfFDVwSZSF8VxgQA670itTBNq3kk6geq1X41A==
+"@next/swc-darwin-arm64@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.23.tgz#beb461aa69f8270ca924c106b60e7b97d62d07d4"
+  integrity sha512-1rd6Oj1bo7FUdAW5rL7yX97suXnrEuQoO8J6oezV4Q4jECaGpTg68J6FvoAb1Hu73b9/ErHrlYXXVoF9OZVxmQ==
 
-"@next/swc-darwin-x64@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.16.tgz#d34955abd2b6ae6507d5a7ecec35cd3a501f472c"
-  integrity sha512-X95zXPegmiEeoeF00Vz7AYAmI3AoofenrmZ1TU+huAj0JrpZ7QKG4LrKPZbtiDIhmR6kSuEdtDvlMw15kaA0lg==
+"@next/swc-darwin-x64@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.23.tgz#fee3bc1d28cfce8795569655f09b9f8f6e5e78d7"
+  integrity sha512-l97PDBpEadxZv6Qotd0WI99BxKEO3fKneVxNXg4bpf9McKXERi6eaAZvUWlNFMavcwssmX1ez5zNPrvcHP47pQ==
 
-"@next/swc-freebsd-x64@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.16.tgz#5999ffd3f0e710842568121a4527ab68ab1a1f02"
-  integrity sha512-yH/72tv8qZVLXB5OOUzo4OZCpwg7IoXot6Vd6Lck/niMbn+EgC8Nb27TZGOZVyPaNjwxqchMPR0nYmvsQke/0A==
+"@next/swc-freebsd-x64@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.23.tgz#0ab0d75122d7093dbb5b15260f645c398ec5f536"
+  integrity sha512-HB9bkQ2AqXFMxe9lhZMPG+ZWKGtDxc2563UmuURX8VByHN0I7GrZEj64ThtE59ioVsT+rOPzcZrlZCbQBFhpyA==
 
-"@next/swc-linux-arm-gnueabihf@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.16.tgz#536e88775ddf520763c4a88f79ecd31ca881fc72"
-  integrity sha512-66jnwNJC+jESiiO6ReUV046u77XYK1nnpf4n71IAqKl5H5KF/QlO7PV+KNMl0UNhILN6RpF6K87lbM+Hq4Ygjw==
+"@next/swc-linux-arm-gnueabihf@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.23.tgz#95ee61abf14db469a6d64b8834004be84c003464"
+  integrity sha512-YRhlxl++AyXcvh0AWr9AkUJUJIkufxnMTUzIAmeOpCObIs6ymXb1MMBxeMJrVm7aV2V09txdff0cIvED/iJFng==
 
-"@next/swc-linux-arm64-gnu@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.16.tgz#88011c3495cb4106cc9fc6fb0fbd4ce7e50e97ec"
-  integrity sha512-Uj9tSd6rK+fuql8lDcmGZmPh6O/6Ld5xNIZH0gRGYHC/tNUTOPgTxo9Fixebkc1ELWBIspxNINx557OGgceltg==
+"@next/swc-linux-arm64-gnu@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.23.tgz#d3500729c812a48676d8dc9b14dcd5b3ee4a5a3f"
+  integrity sha512-4MLGUmfwu0/wAvTgvXXLD2DNMyhdBiN0QQoFw0cS1eWAZVCuv72QipNZ+6oTN7Ae7o/qES5Oi+vlBDdnEwRmDg==
 
-"@next/swc-linux-arm64-musl@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.16.tgz#6dd48a44bce3e1db9dd271f646d0e859c927dd3e"
-  integrity sha512-hhGkJRuSO/ML6Kvne9H2EMY6VdmR/39ZJXoH6IOG7t6qRGSmW3q0Nhhdfdz6lT2a7EhggMd81La76UOkx0ZuAQ==
+"@next/swc-linux-arm64-musl@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.23.tgz#ec52eb8b50091bd12d6f252501cc8157fe904228"
+  integrity sha512-4iOVzAo2AdCYTEvObJYWYOyagMGe0WWjcBrv1GJ4obJ3qIxSg4lbhoZZuOGv3xYQKdU4ZgXHceZinRqxgGYAiw==
 
-"@next/swc-linux-x64-gnu@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.16.tgz#1b694f97e0f5261c3fc3c6b0023cf0d821df95d9"
-  integrity sha512-8oB8WEVtWc6PPEzwA6sqiVyZ/hz/MZnoG9Thsg2mNMKCbF2C1xrObsMvGl61vMTvjxQDOguDoJFY57AUlorHcQ==
+"@next/swc-linux-x64-gnu@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.23.tgz#67dc25ff595c2dd14682f109d943507ebfe0b944"
+  integrity sha512-6DLsKEKuPkknp1yuvPpE18n10Y9N0shHDQWjPPQFKqZqvz7px3O8EUF6EB1KR1PRR7xwcLoWLf33N2s/Sr8rFQ==
 
-"@next/swc-linux-x64-musl@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.16.tgz#3e638258dacedb6a3f6973a907d8c8c3b4648688"
-  integrity sha512-fw2DD9yApjdfbaMUDyRx8yrdJvQurrmqyxhSBHse7lo929eIRkPl6N1/PpDenPn4spftv9uZ5qYguOmvCRU3FQ==
+"@next/swc-linux-x64-musl@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.23.tgz#c8acd44b8f62fa56caf5bb4be065aa4a71842d1e"
+  integrity sha512-2EORnA604df14DxwYmvZ5DK0JE+lCk5kEAjGIAmvIW2R5DNB93wQ+RjrKn5fsKpyB/HqKRZjgC5zLeqMTP91OQ==
 
-"@next/swc-win32-arm64-msvc@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.16.tgz#b9be87acad4dfde3957866e7a8a64eaa5bb83d58"
-  integrity sha512-D3YxibVZRymUg4N1gi5zdLsaLPz/wllDy/jj5umip7PBgtdevDRncaxLOzK6i8uvHUzziqeW9pToXVycB2BNyw==
+"@next/swc-win32-arm64-msvc@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.23.tgz#3f100bfd6a489093e350beaf3784b21e11e75bb9"
+  integrity sha512-BXVJ/1NTBeOpoeNVM7aTxY2LG0a1frjn7XynSeObLo8V8RAj33rJdAzQm2wSF2DbpfC3PFBjmvzajfcVqrwiWQ==
 
-"@next/swc-win32-ia32-msvc@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.16.tgz#580e9264c2f882aadbae532263257c8c652f68fa"
-  integrity sha512-q3oskcJXPxF+nk9g1IDiEupYgM/i0ssYU6q37jxBy2kjucO6/2rKwNw5M9xQ/cLwzPlnrf4gPvEN7ZhND1Lzrg==
+"@next/swc-win32-ia32-msvc@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.23.tgz#0a61911760912ccf4570d777ee090d5811807986"
+  integrity sha512-/nJXWnCobRfIRgrCGmkHmdqAfiG1S9jKRY06Ene44XI0j7lzb5DBXPFELK7zuZuBDriZALvpaejv6E4wLP+pnQ==
 
-"@next/swc-win32-x64-msvc@12.1.7-canary.16":
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.16.tgz#6000d3bf2b9ffe88ee669c909d7a23fb7b1e7334"
-  integrity sha512-FnWqfBS1WE+rj+91uap2EzafSBXJsP0AYWBG7a9DfACJnnIQwbVZVL5qOV/y6ZICrWClhLPSU4dNEFPqAlPNUQ==
+"@next/swc-win32-x64-msvc@12.1.7-canary.23":
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.23.tgz#674da3aa072b56aab1aaa3aab3f0e73968f857bc"
+  integrity sha512-GV9QRyYt9qLKya3W7cvJscfYVyytmgUn1N3CKDRhDc2VU4H7w1cE5sexPVNuAoxYAW6RoViXHcEQUrwp2z2X0A==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5412,30 +5412,30 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
-next@^12.1.7-canary.6:
-  version "12.1.7-canary.16"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.1.7-canary.16.tgz#295c02f7b4f6604031faeed8535b4fbcc4333cae"
-  integrity sha512-8Zf4I7a/leSXxjlNyXJN6EYfYxcdasMfDaMtl6FHaBSeWkShhn1OxD1iFb90V6kYMDfHpeYaYUW/hLBfOtmI2A==
+next@^12.1.7-canary.23:
+  version "12.1.7-canary.23"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.1.7-canary.23.tgz#6a638dbfba4871c32e8bd2bb38515c58118d83da"
+  integrity sha512-ey+hj7RCsKe+idmpaQb/vxVY0/hzYpquOPvTyIQVdaerHMtlfcxPe84QlG7eoXj5d8OhIkF7NPqTqMeJP707PA==
   dependencies:
-    "@next/env" "12.1.7-canary.16"
+    "@next/env" "12.1.7-canary.23"
     caniuse-lite "^1.0.30001332"
     postcss "8.4.5"
     styled-jsx "5.0.2"
     use-sync-external-store "1.1.0"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.1.7-canary.16"
-    "@next/swc-android-arm64" "12.1.7-canary.16"
-    "@next/swc-darwin-arm64" "12.1.7-canary.16"
-    "@next/swc-darwin-x64" "12.1.7-canary.16"
-    "@next/swc-freebsd-x64" "12.1.7-canary.16"
-    "@next/swc-linux-arm-gnueabihf" "12.1.7-canary.16"
-    "@next/swc-linux-arm64-gnu" "12.1.7-canary.16"
-    "@next/swc-linux-arm64-musl" "12.1.7-canary.16"
-    "@next/swc-linux-x64-gnu" "12.1.7-canary.16"
-    "@next/swc-linux-x64-musl" "12.1.7-canary.16"
-    "@next/swc-win32-arm64-msvc" "12.1.7-canary.16"
-    "@next/swc-win32-ia32-msvc" "12.1.7-canary.16"
-    "@next/swc-win32-x64-msvc" "12.1.7-canary.16"
+    "@next/swc-android-arm-eabi" "12.1.7-canary.23"
+    "@next/swc-android-arm64" "12.1.7-canary.23"
+    "@next/swc-darwin-arm64" "12.1.7-canary.23"
+    "@next/swc-darwin-x64" "12.1.7-canary.23"
+    "@next/swc-freebsd-x64" "12.1.7-canary.23"
+    "@next/swc-linux-arm-gnueabihf" "12.1.7-canary.23"
+    "@next/swc-linux-arm64-gnu" "12.1.7-canary.23"
+    "@next/swc-linux-arm64-musl" "12.1.7-canary.23"
+    "@next/swc-linux-x64-gnu" "12.1.7-canary.23"
+    "@next/swc-linux-x64-musl" "12.1.7-canary.23"
+    "@next/swc-win32-arm64-msvc" "12.1.7-canary.23"
+    "@next/swc-win32-ia32-msvc" "12.1.7-canary.23"
+    "@next/swc-win32-x64-msvc" "12.1.7-canary.23"
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
Next.js has this warning:
```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

And this somehow creates a mismatch between server and client rendering, causing these errors to show up on Sentry:
```
Uncaught Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.
```

The fix was to use <span> instead of <div> in the <p>. You can read more about "<div> vs <span>" here: https://blog.hubspot.com/website/span-vs-div and about what issues can using <div> inside of <p> can cause here: https://stackoverflow.com/a/62015689/6099842