### PR TITLE
Add thousand separator for readability

### DIFF
--- a/src/components/EtherFormatted.tsx
+++ b/src/components/EtherFormatted.tsx
@@ -10,8 +10,14 @@ const EtherFormatted: FC<{ wei: BigNumberish }> = ({ wei }) => {
 
   const ether = ethers.utils.formatEther(wei);
   const isRounded = ether.split(".")[1].length > etherDecimalPlaces;
+  let stringAmount = new Decimal(ether).toDP(etherDecimalPlaces).toFixed();
 
-  return <>{isRounded && "~"}{new Decimal(ether).toDP(etherDecimalPlaces).toFixed()}</>;
+  if(stringAmount.includes('.')) {
+    const seperateStringByDecimal = stringAmount.split(".");
+    const formattedAmount = seperateStringByDecimal[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    stringAmount = formattedAmount + "." + seperateStringByDecimal[1];
+  }
+  return <>{isRounded && "~"}{stringAmount}</>;
 };
 
 export default EtherFormatted;


### PR DESCRIPTION
I think this makes the large numbers a little more readable 🙂
I did everything with string manipulation to avoid messing around with big numbers.

<img width="359" alt="Screenshot 2022-06-10 at 16 22 40" src="https://user-images.githubusercontent.com/9613565/173098825-4822fef3-f57d-4391-8408-870c86910f42.png">
