### PR TITLE
Add query params to /super-tokens page for filter + pagination

### DIFF
--- a/src/components/Tables/SuperTokensTable.tsx
+++ b/src/components/Tables/SuperTokensTable.tsx
@@ -104,7 +104,7 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
   const urlQueryParams = new URLSearchParams(window.location.search);
   const defaultFilter: Token_Filter = {
     isSuperToken: true,
-    ...(urlQueryParams.get("isListed") && {isListed: urlQueryParams.get("isListed") === "true"}),
+    ...(urlQueryParams.get("isListed") && {isListed: urlQueryParams.get("isListed") === "true"}), // if the param exists, convert to bool and add to object
     ...(urlQueryParams.get("name_contains") && {name_contains: urlQueryParams.get("name_contains")}),
     ...(urlQueryParams.get("symbol_contains") && {symbol_contains: urlQueryParams.get("symbol_contains")}),
   };
@@ -162,7 +162,7 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
       take: queryArg.pagination.take,
       skip: (newPage - 1) * queryArg.pagination.take,
     }
-    newPage != 1 ? setUrlQueryParam(urlParams) : deleteUrlQueryParams(["skip", "take"]);
+    newPage === 1 ? deleteUrlQueryParams(["skip", "take"]) : setUrlQueryParam(urlParams); // Don't add params for page 1
     onQueryArgsChanged(
       set("pagination.skip", (newPage - 1) * queryArg.pagination.take, queryArg)
     );
@@ -193,7 +193,7 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
 
   const onFilterChange = (newFilter: Token_Filter) => {
     setUrlQueryParam(newFilter);
-    deleteUrlQueryParams(["take", "skip"]);
+    deleteUrlQueryParams(["take", "skip"]); // Pagination resets when filter changes
     onQueryArgsChanged({
       ...queryArg,
       pagination: { ...queryArg.pagination, skip: 0 },

--- a/src/components/Tables/SuperTokensTable.tsx
+++ b/src/components/Tables/SuperTokensTable.tsx
@@ -54,9 +54,6 @@ type RequiredTokensQuery = Required<Omit<TokensQuery, "block">>;
 
 const defaultOrdering = {} as Ordering<Token_OrderBy>;
 
-const defaultFilter: Token_Filter = {
-  isSuperToken: true,
-};
 
 export const defaultPaging = createSkipPaging({
   take: 10,
@@ -96,6 +93,14 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
     window.history.replaceState({}, "", url.toString());
   };
 
+  const urlQueryParams = new URLSearchParams(window.location.search);
+  const defaultFilter: Token_Filter = {
+    isSuperToken: true,
+    ...(urlQueryParams.get("isListed") && {isListed: urlQueryParams.get("isListed") === "true"}),
+    ...(urlQueryParams.get("name_contains") && {name_contains: urlQueryParams.get("name_contains")}),
+    ...(urlQueryParams.get("symbol_contains") && {symbol_contains: urlQueryParams.get("symbol_contains")}),
+  };
+
   const createDefaultArg = (): RequiredTokensQuery => ({
     chainId: network.chainId,
     filter: defaultFilter,
@@ -126,6 +131,11 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
 
   useEffect(() => {
     onQueryArgsChanged(createDefaultArg());
+    const isListedQueryParam = urlQueryParams.get("isListed");
+    if(isListedQueryParam) {
+      const isListedQueryParamBoolean = isListedQueryParam === "true";
+      isListedQueryParamBoolean ? setListedStatus(ListedStatus.Listed) : setListedStatus(ListedStatus.NotListed);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [network]);
 

--- a/src/components/Tables/SuperTokensTable.tsx
+++ b/src/components/Tables/SuperTokensTable.tsx
@@ -74,15 +74,12 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
     const { name_contains, isListed, symbol_contains, skip, take } = paramObject;
     const url = new URL(window.location.href);
 
-    name_contains && url.searchParams.set("name_contains", name_contains);
-    if (name_contains?.length === 1) url.searchParams.delete("name_contains");
+    name_contains && (name_contains.length != 1) && url.searchParams.set("name_contains", name_contains);
 
     if (isListed != undefined)
       url.searchParams.set("isListed", isListed.toString());
 
-    symbol_contains && url.searchParams.set("symbol_contains", symbol_contains);
-    if (symbol_contains?.length === 1)
-      url.searchParams.delete("symbol_contains");
+    symbol_contains && (symbol_contains.length != 1) && url.searchParams.set("symbol_contains", symbol_contains);
 
     skip && url.searchParams.set("skip", skip.toString());
     take && url.searchParams.set("take", take.toString());

--- a/src/components/Tables/SuperTokensTable.tsx
+++ b/src/components/Tables/SuperTokensTable.tsx
@@ -68,6 +68,34 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
 
   const [listedStatus, setListedStatus] = useState<ListedStatus | null>(null);
 
+  const setUrlQueryParam = (newFilter: Token_Filter) => {
+    const { name_contains, isListed, symbol_contains } = newFilter;
+    const url = new URL(window.location.href);
+
+    name_contains && url.searchParams.set("name_contains", name_contains);
+    if (name_contains?.length === 1) url.searchParams.delete("name_contains");
+
+    if (isListed != undefined)
+      url.searchParams.set("isListed", isListed.toString());
+
+    symbol_contains && url.searchParams.set("symbol_contains", symbol_contains);
+    if (symbol_contains?.length === 1)
+      url.searchParams.delete("symbol_contains");
+
+    window.history.replaceState({}, "", url.toString());
+  };
+
+  const deleteUrlQueryParam = (param: string) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(param);
+    window.history.replaceState({}, "", url.toString());
+  };
+
+  const resetUrl = () => {
+    const url = new URL(window.location.origin + window.location.pathname);
+    window.history.replaceState({}, "", url.toString());
+  };
+
   const createDefaultArg = (): RequiredTokensQuery => ({
     chainId: network.chainId,
     filter: defaultFilter,
@@ -129,6 +157,7 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
   };
 
   const onFilterChange = (newFilter: Token_Filter) => {
+    setUrlQueryParam(newFilter);
     onQueryArgsChanged({
       ...queryArg,
       pagination: { ...queryArg.pagination, skip: 0 },
@@ -138,8 +167,10 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
 
   const clearFilterField =
     (...fields: Array<keyof Token_Filter>) =>
-    () =>
+    () => {
       onFilterChange(omit(fields, queryArg.filter));
+      deleteUrlQueryParam(fields[0]);
+    };
 
   const onNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.value) {
@@ -187,7 +218,10 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
   const onListedStatusChange = (_event: unknown, newStatus: ListedStatus) =>
     changeListedStatus(newStatus);
 
-  const clearListedStatusFilter = () => changeListedStatus(null);
+  const clearListedStatusFilter = () => {
+    changeListedStatus(null);
+    deleteUrlQueryParam("isListed");
+  };
 
   const openFilter = () => setShowFilterMenu(true);
   const closeFilter = () => setShowFilterMenu(false);
@@ -201,6 +235,7 @@ const SuperTokensTable: FC<SuperTokensTableProps> = ({ network }) => {
     clearListedStatusFilter();
     onFilterChange(defaultFilter);
     closeFilter();
+    resetUrl();
   };
 
   const hasNextPage = !!queryResult.data?.nextPaging;

--- a/src/redux/balanceFetcher.ts
+++ b/src/redux/balanceFetcher.ts
@@ -80,7 +80,7 @@ const createFetching = (
                 balance: ethers.BigNumber.from(
                   realtimeBalanceOfNowCall.returnValues[0]
                 ).toString(),
-                balanceTimestamp: realtimeBalanceOfNowCall.returnValues[3],
+                balanceTimestamp: ethers.BigNumber.from(realtimeBalanceOfNowCall.returnValues[3]).toNumber(),
                 flowRate: ethers.BigNumber.from(
                   getNetFlowCall.returnValues[0]
                 ).toString(),


### PR DESCRIPTION
@kasparkallas This PR includes logic for handling pagination which the previous PR lacked. 
I chose not to serialise the filter purely because the URL looks nicer compared to a stringified object in the address bar. There is also some logic in `setUrlQueryParam()`  for handling 1 letter filters.