### PR TITLE
Testnet visibility improvements 

### DIFF
--- a/cypress/integration/Common.feature
+++ b/cypress/integration/Common.feature
@@ -2,6 +2,7 @@ Feature: Test cases for common elements and functionalities
 
   Scenario Outline: Searching for an address
     Given User has opened the "landing" page
+    And User enables all of the testnets
     And User opens search dialog
     And User searches for static balance account
     And User opens the "<network>" account result

--- a/cypress/integration/Common/Common.ts
+++ b/cypress/integration/Common/Common.ts
@@ -81,3 +81,6 @@ Given(`User has opened the {string} read more page`, (page) => {
 Then(`There are no elements containing {string}`, (text) => {
   BasePage.notContains(text)
 });
+Given(`User enables all of the testnets`,  () => {
+  CommonElements.enableAllTestnets()
+});

--- a/cypress/pageObjects/components/CommonElements.ts
+++ b/cypress/pageObjects/components/CommonElements.ts
@@ -18,6 +18,7 @@ const STREAM_GRANULARITY_GROUP = "[data-cy=stream-granularity-button-group]"
 const SETTINGS_BUTTON = "[data-testid=SettingsOutlinedIcon]"
 const FILTER_BUTTON = "[data-testid=FilterListIcon]"
 const FILTER_RESET_BUTTON = "[data-cy=reset-filter]"
+const SETTINGS_TESTNET_SWITCHES = "[data-cy=testnet-switch]"
 
 export class CommonElements extends BasePage {
 
@@ -120,5 +121,11 @@ export class CommonElements extends BasePage {
   static resetFilter() {
     this.click(FILTER_BUTTON)
     this.click(FILTER_RESET_BUTTON)
+  }
+
+  static enableAllTestnets() {
+    this.click(SETTINGS_BUTTON)
+    cy.get(SETTINGS_TESTNET_SWITCHES).click({multiple:true})
+    this.click(SETTINGS_CLOSE_BUTTON)
   }
 }

--- a/src/components/NetworkDisplay.tsx
+++ b/src/components/NetworkDisplay.tsx
@@ -1,9 +1,31 @@
-import { Box } from "@mui/material";
+import { Badge, Box } from "@mui/material";
 import { FC } from "react";
 import { Network } from "../redux/networks";
+import ScienceIcon from "@mui/icons-material/Science";
 
 const NetworkDisplay: FC<{ network: Network }> = ({ network }) => {
-  return <Box sx={{ fontSize: "inherit" }}>{`${network.displayName}`}</Box>;
+  return network.isTestnet ? (
+    <Badge
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "right",
+      }}
+      badgeContent={<ScienceIcon sx={{ fontSize: "1.2em" }} />}
+      sx={{
+        "& .MuiBadge-badge": {
+          bottom: "4px",
+          paddingLeft: "20px",
+        },
+      }}
+    >
+      {network.displayName}
+    </Badge>
+  ) : (
+    <Box
+      component="span"
+      sx={{ fontSize: "inherit" }}
+    >{`${network.displayName}`}</Box>
+  );
 };
 
 export default NetworkDisplay;

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -1,3 +1,7 @@
+import CloseIcon from "@mui/icons-material/Close";
+import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import SettingsBrightnessIcon from "@mui/icons-material/SettingsBrightness";
 import {
   Box,
   Divider,
@@ -8,16 +12,18 @@ import {
   ToggleButtonGroup,
   Typography,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import LightModeIcon from "@mui/icons-material/LightMode";
-import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
-import SettingsBrightnessIcon from "@mui/icons-material/SettingsBrightness";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Switch from "@mui/material/Switch";
+import sortBy from "lodash/sortBy";
 import { FC } from "react";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { networksByChainId } from "../redux/networks";
 import {
-  changeThemePreference,
-  changeStreamGranularity,
+  changeDisplayedTestnets,
   changeEtherDecimalPlaces,
+  changeStreamGranularity,
+  changeThemePreference,
 } from "../redux/slices/appPreferences.slice";
 import InfoTooltipBtn from "./InfoTooltipBtn";
 
@@ -53,6 +59,13 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
   );
   const currentEtherDecimalPlaces = useAppSelector(
     (state) => state.appPreferences.etherDecimalPlaces
+  );
+
+  const currentDisplayedTestNets = useAppSelector((state) =>
+    sortBy(
+      Object.entries(state.appPreferences.displayedTestNets),
+      ([chainId]) => networksByChainId.get(Number(chainId))?.displayName
+    )
   );
 
   return (
@@ -107,7 +120,10 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
 
         <Heading gutterBottom>
           Stream Granularity
-          <InfoTooltipBtn dataCy={"stream-granularity-tooltip"} title="Representation of calculated stream flow in selected time span." />
+          <InfoTooltipBtn
+            dataCy={"stream-granularity-tooltip"}
+            title="Representation of calculated stream flow in selected time span."
+          />
         </Heading>
         <ToggleButtonGroup
           data-cy={"stream-granularity-button-group"}
@@ -161,6 +177,25 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
           <IconToggleButton value="9">9</IconToggleButton>
           <IconToggleButton value="5">5</IconToggleButton>
         </ToggleButtonGroup>
+      </Box>
+      <Box sx={{ pl: 2, pr: 2 }}>
+        <Heading gutterBottom>Display Testnets</Heading>
+        <FormGroup>
+          {currentDisplayedTestNets.map(([chainId, isDisplayed]) => {
+            const numericChainId = Number(chainId);
+
+            return (
+              <FormControlLabel
+                key={chainId}
+                control={<Switch checked={isDisplayed} />}
+                onChange={() =>
+                  dispatch(changeDisplayedTestnets(numericChainId))
+                }
+                label={networksByChainId.get(numericChainId)?.displayName}
+              />
+            );
+          })}
+        </FormGroup>
       </Box>
     </Drawer>
   );

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import CloseIcon from "@mui/icons-material/Close";
 import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
 import LightModeIcon from "@mui/icons-material/LightMode";
+import ScienceIcon from "@mui/icons-material/Science";
 import SettingsBrightnessIcon from "@mui/icons-material/SettingsBrightness";
 import {
   Box,
@@ -15,15 +16,16 @@ import {
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import Switch from "@mui/material/Switch";
+import isEqual from "lodash/isEqual";
 import sortBy from "lodash/sortBy";
 import { FC } from "react";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
 import { networksByChainId } from "../redux/networks";
 import {
-  changeDisplayedTestnets,
   changeEtherDecimalPlaces,
   changeStreamGranularity,
   changeThemePreference,
+  toggleDisplayedTestnets,
 } from "../redux/slices/appPreferences.slice";
 import InfoTooltipBtn from "./InfoTooltipBtn";
 
@@ -61,11 +63,13 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
     (state) => state.appPreferences.etherDecimalPlaces
   );
 
-  const currentDisplayedTestNets = useAppSelector((state) =>
-    sortBy(
-      Object.entries(state.appPreferences.displayedTestNets),
-      ([chainId]) => networksByChainId.get(Number(chainId))?.displayName
-    )
+  const currentDisplayedTestNets = useAppSelector(
+    (state) =>
+      sortBy(
+        Object.entries(state.appPreferences.displayedTestNets),
+        ([chainId]) => networksByChainId.get(Number(chainId))?.displayName
+      ),
+    isEqual
   );
 
   return (
@@ -179,7 +183,10 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
         </ToggleButtonGroup>
       </Box>
       <Box sx={{ pl: 2, pr: 2 }}>
-        <Heading gutterBottom>Display Testnets</Heading>
+        <Heading gutterBottom display="flex" alignItems="flex-end">
+          Display Testnets
+          <ScienceIcon sx={{ fontSize: "16px", marginLeft: "4px" }} />
+        </Heading>
         <FormGroup>
           {currentDisplayedTestNets.map(([chainId, isDisplayed]) => {
             const numericChainId = Number(chainId);
@@ -189,7 +196,7 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
                 key={chainId}
                 control={<Switch checked={isDisplayed} />}
                 onChange={() =>
-                  dispatch(changeDisplayedTestnets(numericChainId))
+                  dispatch(toggleDisplayedTestnets(numericChainId))
                 }
                 label={networksByChainId.get(numericChainId)?.displayName}
               />

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -28,6 +28,7 @@ import {
   toggleDisplayedTestnets,
 } from "../redux/slices/appPreferences.slice";
 import InfoTooltipBtn from "./InfoTooltipBtn";
+import NetworkDisplay from "./NetworkDisplay";
 
 const Heading = styled(Typography)(({ theme }) => ({
   margin: "20px 0 10px",
@@ -185,12 +186,10 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
       <Box sx={{ pl: 2, pr: 2 }}>
         <Heading gutterBottom display="flex" alignItems="flex-end">
           Display Testnets
-          <ScienceIcon sx={{ fontSize: "16px", marginLeft: "4px" }} />
         </Heading>
         <FormGroup>
           {currentDisplayedTestNets.map(([chainId, isDisplayed]) => {
             const numericChainId = Number(chainId);
-
             return (
               <FormControlLabel
                 key={chainId}
@@ -198,7 +197,11 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
                 onChange={() =>
                   dispatch(toggleDisplayedTestnets(numericChainId))
                 }
-                label={networksByChainId.get(numericChainId)?.displayName}
+                label={
+                  <NetworkDisplay
+                    network={networksByChainId.get(numericChainId)!}
+                  />
+                }
               />
             );
           })}

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -192,6 +192,7 @@ const SettingsDrawer: FC<{ open: boolean; onClose: () => void }> = ({
             const numericChainId = Number(chainId);
             return (
               <FormControlLabel
+                data-cy={"testnet-switch"}
                 key={chainId}
                 control={<Switch checked={isDisplayed} />}
                 onChange={() =>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,6 +1,7 @@
-import { Network, networks, networksByChainId } from "../redux/networks";
-import _ from "lodash";
+import { SerializedError } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
+import _ from "lodash";
+import { Network, networks, networksByChainId } from "../redux/networks";
 import { useAddressDisplay } from "./useAddressDisplay";
 import { useSearchAddressBook } from "./useSearchAddressBook";
 import {
@@ -11,7 +12,6 @@ import {
   SubgraphSearchByTokenSymbolResult,
   useSearchSubgraphByTokenSymbol,
 } from "./useSearchSubgraphByTokenSymbol";
-import { SerializedError } from "@reduxjs/toolkit";
 
 export type NetworkSearchResult = {
   network: Network;
@@ -31,7 +31,9 @@ export type NetworkSearchResult = {
 export const useSearch = (searchTerm: string) => {
   const addressDisplay = useAddressDisplay(searchTerm);
 
-  const subgraphSearchByAddressResults = useSearchSubgraphByAddress(addressDisplay.addressChecksummed ?? "skip");
+  const subgraphSearchByAddressResults = useSearchSubgraphByAddress(
+    addressDisplay.addressChecksummed ?? "skip"
+  );
   const subgraphSearchByTokenSymbolResults =
     useSearchSubgraphByTokenSymbol(searchTerm);
   const addressBookResults = useSearchAddressBook(searchTerm);
@@ -63,7 +65,7 @@ export const useSearch = (searchTerm: string) => {
       .filter((x) => !!x.originalArgs)
       .map((searchQuery) => {
         const searchResult: SubgraphSearchByTokenSymbolResult =
-          (searchQuery.data as SubgraphSearchByTokenSymbolResult) ?? {
+          (searchQuery.currentData as SubgraphSearchByTokenSymbolResult) ?? {
             tokensBySymbol: [],
           };
 

--- a/src/hooks/useSearchSubgraphByAddress.ts
+++ b/src/hooks/useSearchSubgraphByAddress.ts
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
+import { skipToken } from "@reduxjs/toolkit/query";
 import { ethers } from "ethers";
+import { gql } from "graphql-request";
+import { useMemo } from "react";
+import { useAppSelector } from "../redux/hooks";
 import { networks } from "../redux/networks";
 import { sfSubgraph } from "../redux/store";
-import { skipToken } from "@reduxjs/toolkit/query";
-import { gql } from "graphql-request";
 
 const searchByAddressDocument = gql`
   query Search($addressId: ID, $addressBytes: Bytes) {
@@ -51,9 +52,14 @@ export const useSearchSubgraphByAddress = (searchTerm: string) => {
     [searchTerm]
   );
 
+  const currentDisplayedNetworks = useAppSelector(
+    (state) => state.appPreferences.displayedTestNets
+  );
+
   return networks.map((network) =>
     sfSubgraph.useCustomQuery(
-      isSearchTermAddress
+      isSearchTermAddress &&
+        (!network.isTestnet || currentDisplayedNetworks[network.chainId])
         ? {
             chainId: network.chainId,
             document: searchByAddressDocument,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { Badge, Card, Divider, NoSsr, Stack, Tab } from "@mui/material";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import isEqual from "lodash/isEqual";
 import type { NextPage } from "next";
 import * as React from "react";
 import AppLink from "../components/AppLink";
@@ -23,10 +24,12 @@ const Home: NextPage = () => {
     ifOlderThan: 45,
   });
 
-  const displayedTestnetChainIds = useAppSelector((state) =>
-    Object.entries(state.appPreferences.displayedTestNets)
-      .filter(([_, isDisplayed]) => isDisplayed)
-      .map(([chainId]) => Number(chainId))
+  const displayedTestnetChainIds = useAppSelector(
+    (state) =>
+      Object.entries(state.appPreferences.displayedTestNets)
+        .filter(([_, isDisplayed]) => isDisplayed)
+        .map(([chainId]) => Number(chainId)),
+    isEqual
   );
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,53 +82,55 @@ const Home: NextPage = () => {
           <Divider />
           <TabContext value={value}>
             <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-              <TabList
-                variant="scrollable"
-                scrollButtons="auto"
-                data-cy={"landing-page-networks"}
-                onChange={(_event, newValue: string) => setValue(newValue)}
-              >
-                {networksByTestAndName
-                  .filter(
-                    (network) =>
-                      !network.isTestnet ||
-                      displayedTestnetChainIds.includes(network.chainId)
-                  )
-                  .map((network) => (
-                    <Tab
-                      data-cy={`${network.slugName}-landing-button`}
-                      key={`Tab_${network.slugName}`}
-                      label={
-                        <Badge
-                          anchorOrigin={{
-                            vertical: "bottom",
-                            horizontal: "right",
-                          }}
-                          invisible={!network.isTestnet}
-                          badgeContent={
-                            <ScienceIcon sx={{ fontSize: "16px" }} />
-                          }
-                          sx={{
-                            "& .MuiBadge-badge": {
-                              bottom: "4px",
-                              paddingLeft: "20px",
-                            },
-                          }}
-                        >
-                          {network.displayName}
-                        </Badge>
-                      }
-                      value={network.slugName}
-                      onMouseEnter={() =>
-                        prefetchStreamsQuery({
-                          chainId: network.chainId,
-                          order: defaultStreamQueryOrdering,
-                          pagination: defaultStreamQueryPaging,
-                        })
-                      }
-                    />
-                  ))}
-              </TabList>
+              <NoSsr>
+                <TabList
+                  variant="scrollable"
+                  scrollButtons="auto"
+                  data-cy={"landing-page-networks"}
+                  onChange={(_event, newValue: string) => setValue(newValue)}
+                >
+                  {networksByTestAndName
+                    .filter(
+                      (network) =>
+                        !network.isTestnet ||
+                        displayedTestnetChainIds.includes(network.chainId)
+                    )
+                    .map((network) => (
+                      <Tab
+                        data-cy={`${network.slugName}-landing-button`}
+                        key={`Tab_${network.slugName}`}
+                        label={
+                          <Badge
+                            anchorOrigin={{
+                              vertical: "bottom",
+                              horizontal: "right",
+                            }}
+                            invisible={!network.isTestnet}
+                            badgeContent={
+                              <ScienceIcon sx={{ fontSize: "16px" }} />
+                            }
+                            sx={{
+                              "& .MuiBadge-badge": {
+                                bottom: "4px",
+                                paddingLeft: "20px",
+                              },
+                            }}
+                          >
+                            {network.displayName}
+                          </Badge>
+                        }
+                        value={network.slugName}
+                        onMouseEnter={() =>
+                          prefetchStreamsQuery({
+                            chainId: network.chainId,
+                            order: defaultStreamQueryOrdering,
+                            pagination: defaultStreamQueryPaging,
+                          })
+                        }
+                      />
+                    ))}
+                </TabList>
+              </NoSsr>
             </Box>
             {networksByTestAndName.map((network) => (
               <TabPanel

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
-import ScienceIcon from "@mui/icons-material/Science";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { Badge, Card, Divider, NoSsr, Stack, Tab } from "@mui/material";
+import { Card, Divider, NoSsr, Stack, Tab } from "@mui/material";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
@@ -8,6 +7,7 @@ import isEqual from "lodash/isEqual";
 import type { NextPage } from "next";
 import * as React from "react";
 import AppLink from "../components/AppLink";
+import NetworkDisplay from "../components/NetworkDisplay";
 import {
   defaultStreamQueryOrdering,
   defaultStreamQueryPaging,
@@ -102,26 +102,7 @@ const Home: NextPage = () => {
                       <Tab
                         data-cy={`${network.slugName}-landing-button`}
                         key={`Tab_${network.slugName}`}
-                        label={
-                          <Badge
-                            anchorOrigin={{
-                              vertical: "bottom",
-                              horizontal: "right",
-                            }}
-                            invisible={!network.isTestnet}
-                            badgeContent={
-                              <ScienceIcon sx={{ fontSize: "16px" }} />
-                            }
-                            sx={{
-                              "& .MuiBadge-badge": {
-                                bottom: "4px",
-                                paddingLeft: "20px",
-                              },
-                            }}
-                          >
-                            {network.displayName}
-                          </Badge>
-                        }
+                        label={<NetworkDisplay network={network} />}
                         value={network.slugName}
                         onMouseEnter={() =>
                           prefetchStreamsQuery({

--- a/src/redux/slices/appPreferences.slice.ts
+++ b/src/redux/slices/appPreferences.slice.ts
@@ -1,10 +1,12 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import {HYDRATE} from "next-redux-wrapper";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { HYDRATE } from "next-redux-wrapper";
+import { Network, networksByTestAndName } from "../networks";
 
 export interface IAppPreferences {
-  themePreference: 'system' | 'light' | 'dark';
+  themePreference: "system" | "light" | "dark";
   streamGranularity: keyof typeof streamGranularityInSeconds;
   etherDecimalPlaces: etherDecimalPlaces;
+  displayedTestNets: Record<Network["chainId"], boolean>;
 }
 
 export const streamGranularityInSeconds = {
@@ -13,39 +15,63 @@ export const streamGranularityInSeconds = {
   hour: 3600,
   day: 86400,
   week: 86400 * 7,
-  month: 86400 * 30
-}
-
-type etherDecimalPlaces = 18 | 9 | 5; 
-
-const initialState: IAppPreferences = {
-  themePreference: 'system',
-  streamGranularity: 'day',
-  etherDecimalPlaces: 18
+  month: 86400 * 30,
 };
 
-const sliceName = 'appPreferences'
+type etherDecimalPlaces = 18 | 9 | 5;
+
+const initialState: IAppPreferences = {
+  themePreference: "system",
+  streamGranularity: "day",
+  etherDecimalPlaces: 18,
+  displayedTestNets: networksByTestAndName
+    .filter((n) => n.isTestnet)
+    .reduce(
+      (acc, n) => ({
+        ...acc,
+        [n.chainId]: false,
+      }),
+      {}
+    ),
+};
+
+const sliceName = "appPreferences";
 
 export const themePreferenceSlice = createSlice({
   name: sliceName,
   initialState: initialState,
   reducers: {
-    changeThemePreference(state, action: PayloadAction<IAppPreferences['themePreference']>) {
+    changeThemePreference(
+      state,
+      action: PayloadAction<IAppPreferences["themePreference"]>
+    ) {
       state.themePreference = action.payload;
     },
-    changeStreamGranularity(state, action: PayloadAction<IAppPreferences['streamGranularity']>) {
+    changeStreamGranularity(
+      state,
+      action: PayloadAction<IAppPreferences["streamGranularity"]>
+    ) {
       state.streamGranularity = action.payload;
     },
     changeEtherDecimalPlaces(state, action: PayloadAction<etherDecimalPlaces>) {
       state.etherDecimalPlaces = action.payload;
     },
+    changeDisplayedTestnets(state, action: PayloadAction<Network["chainId"]>) {
+      state.displayedTestNets[action.payload] =
+        !state.displayedTestNets[action.payload];
+    },
   },
   extraReducers: {
-    [HYDRATE]: (state, {payload}) => ({
+    [HYDRATE]: (state, { payload }) => ({
       ...state,
       ...payload[sliceName],
     }),
   },
 });
 
-export const { changeThemePreference, changeStreamGranularity, changeEtherDecimalPlaces } = themePreferenceSlice.actions;
+export const {
+  changeThemePreference,
+  changeStreamGranularity,
+  changeEtherDecimalPlaces,
+  changeDisplayedTestnets,
+} = themePreferenceSlice.actions;

--- a/src/redux/slices/appPreferences.slice.ts
+++ b/src/redux/slices/appPreferences.slice.ts
@@ -56,7 +56,7 @@ export const themePreferenceSlice = createSlice({
     changeEtherDecimalPlaces(state, action: PayloadAction<etherDecimalPlaces>) {
       state.etherDecimalPlaces = action.payload;
     },
-    changeDisplayedTestnets(state, action: PayloadAction<Network["chainId"]>) {
+    toggleDisplayedTestnets(state, action: PayloadAction<Network["chainId"]>) {
       state.displayedTestNets[action.payload] =
         !state.displayedTestNets[action.payload];
     },
@@ -73,5 +73,5 @@ export const {
   changeThemePreference,
   changeStreamGranularity,
   changeEtherDecimalPlaces,
-  changeDisplayedTestnets,
+  toggleDisplayedTestnets,
 } = themePreferenceSlice.actions;


### PR DESCRIPTION
- added individual toggles to manage the visibility of the testnet tabs
- added icons to visually distinguish testnets among the tabs
- falling back to skipToken in the searchQuery on the (test) networks that are currently filtered. 