### PR TITLE
Local Network Support

### DIFF
--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -14,6 +14,16 @@ export type Network = {
 export const networks: Network[] = [
   // mainnets
   {
+    displayName: "Hardhat",
+    slugName: "localhost",
+    chainId: 31337,
+    isTestnet: true,
+    rpcUrl: "http://127.0.0.1:8545/",
+    subgraphUrl: "http://localhost:8000/subgraphs/name/superfluid-test",
+    getLinkForTransaction: (txHash: string): string => `http://127.0.0.1:8545/`,
+    getLinkForAddress: (address: string): string => `http://127.0.0.1:8545/`,
+  },
+  {
     displayName: "Ethereum",
     slugName: "ethereum",
     chainId: 1,

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -14,16 +14,6 @@ export type Network = {
 export const networks: Network[] = [
   // mainnets
   {
-    displayName: "Hardhat",
-    slugName: "localhost",
-    chainId: 31337,
-    isTestnet: true,
-    rpcUrl: "http://127.0.0.1:8545/",
-    subgraphUrl: "http://localhost:8000/subgraphs/name/superfluid-test",
-    getLinkForTransaction: (txHash: string): string => `http://127.0.0.1:8545/`,
-    getLinkForAddress: (address: string): string => `http://127.0.0.1:8545/`,
-  },
-  {
     displayName: "Ethereum",
     slugName: "ethereum",
     chainId: 1,
@@ -167,6 +157,16 @@ export const networks: Network[] = [
       `https://testnet.snowtrace.io/tx/${txHash}`,
     getLinkForAddress: (address: string): string =>
       `https://testnet.snowtrace.io/address/${address}`,
+  },
+  {
+    displayName: "Hardhat",
+    slugName: "localhost",
+    chainId: 31337,
+    isTestnet: true,
+    rpcUrl: "http://127.0.0.1:8545/",
+    subgraphUrl: "http://localhost:8000/subgraphs/name/superfluid-test",
+    getLinkForTransaction: (txHash: string): string => `http://127.0.0.1:8545/`,
+    getLinkForAddress: (address: string): string => `http://127.0.0.1:8545/`,
   },
 ];
 

--- a/src/redux/protocolContracts.ts
+++ b/src/redux/protocolContracts.ts
@@ -13,6 +13,14 @@ interface NetworkContracts {
 }
 
 const protocolContracts: NetworkContracts = {
+  localhost: {
+    resolver: "0x67913A0F4F407BdBA24EBf89421A519b525a235f",
+    host: "0x06B1D212B8da92b83AF328De5eef4E211Da02097",
+    CFAv1: "0xED179b78D5781f93eb169730D8ad1bE7313123F4",
+    IDAv1: "0x12D18787688944475C280A121c31Ed9F1c318351",
+    superTokenFactory: "0x4cBD79D2EEF2f1b36D07b57844CdF773C0F2926b",
+    superfluidLoaderv1: "",
+  },
   ethereum: {
     resolver: "0xeE4cD028f5fdaAdeA99f8fc38e8bA8A57c90Be53",
     host: "0x4E583d9390082B65Bef884b629DFA426114CED6d",

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -46,7 +46,17 @@ export const sfSubgraph = initializeSubgraphApiSlice(
 const infuraProviders = networks.map((network) => ({
   chainId: network.chainId,
   frameworkGetter: () =>
-    Framework.create({
+  network.chainId == 31337? 
+  (Framework.create({
+    chainId: network.chainId,
+    provider: new providers.MulticallProvider(
+      new ethers.providers.StaticJsonRpcProvider(network.rpcUrl)
+    ),
+    customSubgraphQueriesEndpoint: network.subgraphUrl,
+    resolverAddress: "0x67913A0F4F407BdBA24EBf89421A519b525a235f", //hardcode resolver address for local network
+    protocolReleaseVersion: 'test'
+  })) :
+  Framework.create({
       chainId: network.chainId,
       provider: new providers.MulticallProvider(
         new ethers.providers.StaticJsonRpcProvider(network.rpcUrl)


### PR DESCRIPTION
Supporting Hardhat as a testnet option. 

Note that, by default, no data will be available when hardhat is selected.

**Potential Next Steps/changes beyond this PR:**
-Allow for optional subgraph endpoints and optional local rpc urls
-Rename 'Hardhat' to 'Localhost' to imply support for Anvil, Ganache

Note that a new example repo is in development which will make running a local subgraph + deploying the framework locally as simple as possible
