### PR TITLE
Support chain IDs and @superfluid-finance/metadata names for slugs 

### DIFF
--- a/src/components/SfAppBar.tsx
+++ b/src/components/SfAppBar.tsx
@@ -16,12 +16,13 @@ import AppLink from "./AppLink";
 import SearchBar from "./SearchBar";
 import SearchDialog from "./SearchDialog";
 import SettingsDrawer from "./SettingsDrawer";
+import { polygon } from "../redux/networks";
 
 export const SfAppBar = () => {
   const [searchOpen, setSearchOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const router = useRouter();
-  const { _network = "polygon-mainnet" } = router.query;
+  const { _network = polygon.slugName } = router.query;
 
   return (
     <>

--- a/src/pages/[_network]/protocol.tsx
+++ b/src/pages/[_network]/protocol.tsx
@@ -96,7 +96,7 @@ const Protocol: NextPage = () => {
     GDAv1,
     flowScheduler,
     vestingScheduler,
-  } = protocolContracts[network.slugName] || {};
+  } = protocolContracts[network.chainId] || {};
 
   return (
     <Container component={Box} sx={{ my: 2, py: 2 }}>

--- a/src/pages/[_network]/protocol.tsx
+++ b/src/pages/[_network]/protocol.tsx
@@ -96,7 +96,7 @@ const Protocol: NextPage = () => {
     GDAv1,
     flowScheduler,
     vestingScheduler,
-  } = protocolContracts[network.chainId] || {};
+  } = protocolContracts[network.slugName] || {};
 
   return (
     <Container component={Box} sx={{ my: 2, py: 2 }}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,13 +15,14 @@ import { FeatureFlagProvider } from "../contexts/FeatureFlagContext";
 import IdContext from "../contexts/IdContext";
 import { NetworkContext } from "../contexts/NetworkContext";
 import { useMatomo } from "../hooks/useMatomo";
-import { tryGetNetwork, tryGetString } from "../redux/networks";
+import { networks, tryGetString } from "../redux/networks";
 import { wrapper } from "../redux/store";
 import "../styles/app.css";
 import "../styles/graphiql.min.css";
 import useSfTheme from "../styles/useSfTheme";
 import createEmotionCache from "../utils/createEmotionCache";
 import { isDynamicRoute } from "../utils/isDynamicRoute";
+import { tryFindNetwork } from "../utils/findNetwork";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -109,7 +110,7 @@ const Layout: FC<PropsWithChildren<unknown>> = ({ children }) => {
   // For dynamic routes, pre-load the network and the entity ID. Makes the specific page implementations less boilerplate-y.
   if (isDynamicRoute(router)) {
     if (router.isReady) {
-      const network = tryGetNetwork(_network);
+      const network = tryFindNetwork(networks, _network);
       const id = tryGetString(_id);
 
       if (network && id) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,10 +8,10 @@ import * as React from "react";
 import AppLink from "../components/AppLink";
 import { NetworkStreams } from "../components/NetworkStreams";
 import NetworkTabs from "../components/NetworkTabs";
-import { networks } from "../redux/networks";
+import { networks, polygon } from "../redux/networks";
 
 const Home: NextPage = () => {
-  const [activeTab, setActiveTab] = React.useState("polygon-mainnet");
+  const [activeTab, setActiveTab] = React.useState(polygon.slugName);
 
   return (
     <>

--- a/src/pages/protocol.tsx
+++ b/src/pages/protocol.tsx
@@ -1,10 +1,11 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { polygon } from "../redux/networks";
 
 const ProtocolRedirect: NextPage = () => {
     const router = useRouter();
-    useEffect(() => void router.replace("/polygon-mainnet/protocol") ,[]);
+    useEffect(() => void router.replace(`/${polygon.slugName}/protocol`), []);
 
     return null;
 };

--- a/src/pages/super-tokens.tsx
+++ b/src/pages/super-tokens.tsx
@@ -1,11 +1,12 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { polygon } from "../redux/networks";
 
 // redirects the legacy url /super-tokens to the default network specific page
 const SuperTokensLegacyRedirect: NextPage = () => {
     const router = useRouter();
-    useEffect(() => void router.replace("/polygon-mainnet/supertokens") ,[]);
+    useEffect(() => void router.replace(`/${polygon.slugName}/supertokens`), []);
 
     return null;
 };

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -15,7 +15,7 @@ export const networks: Network[] = [
   // mainnets
   {
     displayName: "Ethereum",
-    slugName: "eth-mainnet",
+    slugName: "ethereum",
     chainId: 1,
     isTestnet: false,
     rpcUrl: "https://rpc-endpoints.superfluid.dev/eth-mainnet",
@@ -28,7 +28,7 @@ export const networks: Network[] = [
   },
   {
     displayName: "Gnosis Chain",
-    slugName: "xdai-mainnet",
+    slugName: "xdai",
     chainId: 100,
     isTestnet: false,
     rpcUrl: "https://rpc-endpoints.superfluid.dev/xdai-mainnet",
@@ -41,7 +41,7 @@ export const networks: Network[] = [
   },
   {
     displayName: "Polygon",
-    slugName: "polygon-mainnet",
+    slugName: "matic",
     chainId: 137,
     isTestnet: false,
     rpcUrl: `https://rpc-endpoints.superfluid.dev/polygon-mainnet`,
@@ -93,7 +93,7 @@ export const networks: Network[] = [
   },
   {
     displayName: "BNB Smart Chain",
-    slugName: "bsc-mainnet",
+    slugName: "bnb-smart-chain",
     chainId: 56,
     isTestnet: false,
     rpcUrl: `https://bsc-dataseed1.binance.org`,
@@ -106,7 +106,7 @@ export const networks: Network[] = [
   },
   {
     displayName: "Celo",
-    slugName: "celo-mainnet",
+    slugName: "celo",
     chainId: 42220,
     isTestnet: false,
     rpcUrl: "https://rpc-endpoints.superfluid.dev/celo-mainnet",
@@ -121,7 +121,7 @@ export const networks: Network[] = [
   // testnets
   {
     displayName: "Goerli",
-    slugName: "eth-goerli",
+    slugName: "goerli",
     chainId: 5,
     isTestnet: true,
     rpcUrl: `https://rpc-endpoints.superfluid.dev/eth-goerli`,
@@ -134,7 +134,7 @@ export const networks: Network[] = [
   },
   {
     displayName: "Mumbai",
-    slugName: "polygon-mumbai",
+    slugName: "mumbai",
     chainId: 80001,
     isTestnet: true,
     rpcUrl: `https://rpc-endpoints.superfluid.dev/polygon-mumbai`,
@@ -200,7 +200,7 @@ export const networks: Network[] = [
   {
     isTestnet: true,
     chainId: 1442,
-    slugName: "polygon-zkevm-testnet",
+    slugName: "pzkevmtest",
     displayName: "Polygon zkEVM Testnet",
     rpcUrl: "https://rpc-endpoints.superfluid.dev/polygon-zkevm-testnet",
     subgraphUrl: "https://polygon-zkevm-testnet.subgraph.x.superfluid.dev",
@@ -212,7 +212,7 @@ export const networks: Network[] = [
   {
     isTestnet: true,
     chainId: 84531,
-    slugName: "base-goerli",
+    slugName: "bgoerli",
     displayName: "Base Goerli",
     rpcUrl: "https://rpc-endpoints.superfluid.dev/base-goerli",
     subgraphUrl: "https://base-goerli.subgraph.x.superfluid.dev/",

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -2,7 +2,7 @@ import sortBy from "lodash/fp/sortBy";
 
 export type Network = {
   displayName: string;
-  slugName: string;
+  slugName: string; // The displayed slug by default. To find network by slug, use `tryFindNetwork` which looks from more sources.
   chainId: number;
   rpcUrl: string;
   subgraphUrl: string;
@@ -190,7 +190,8 @@ export const networks: Network[] = [
     slugName: "eth-sepolia",
     displayName: "Sepolia",
     rpcUrl: "https://rpc-endpoints.superfluid.dev/eth-sepolia",
-    subgraphUrl: "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-sepolia/api",
+    subgraphUrl:
+      "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-sepolia/api",
     getLinkForTransaction: (txHash: string): string =>
       `https://sepolia.etherscan.io/tx/${txHash}`,
     getLinkForAddress: (address: string): string =>
@@ -228,24 +229,12 @@ export const networksByName = new Map(
 
 export const networksByChainId = new Map(networks.map((x) => [x.chainId, x]));
 
+export const polygon = networksByChainId.get(137)!;
+
 export const networksByTestAndName = sortBy(
   [(x) => x.isTestnet, (x) => x.slugName],
   networks
 );
-
-export const tryGetNetwork = (x: unknown): Network | undefined => {
-  let network: Network | undefined = undefined;
-
-  if (typeof x === "string") {
-    network = networksByName.get(x.toLowerCase());
-  }
-
-  if (typeof x === "number") {
-    network = networksByChainId.get(x);
-  }
-
-  return network;
-};
 
 export const tryGetString = (x: unknown): string | undefined => {
   if (typeof x === "string") {

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -200,7 +200,7 @@ export const networks: Network[] = [
   {
     isTestnet: true,
     chainId: 1442,
-    slugName: "pzkevmtest",
+    slugName: "polygon-zkevm-testnet",
     displayName: "Polygon zkEVM Testnet",
     rpcUrl: "https://rpc-endpoints.superfluid.dev/polygon-zkevm-testnet",
     subgraphUrl: "https://polygon-zkevm-testnet.subgraph.x.superfluid.dev",
@@ -212,7 +212,7 @@ export const networks: Network[] = [
   {
     isTestnet: true,
     chainId: 84531,
-    slugName: "bgoerli",
+    slugName: "base-goerli",
     displayName: "Base Goerli",
     rpcUrl: "https://rpc-endpoints.superfluid.dev/base-goerli",
     subgraphUrl: "https://base-goerli.subgraph.x.superfluid.dev/",

--- a/src/redux/protocolContracts.ts
+++ b/src/redux/protocolContracts.ts
@@ -1,4 +1,6 @@
 import metadata from "@superfluid-finance/metadata";
+import { networksByChainId } from "./networks";
+import { findNetworkOrThrow } from "../utils/findNetwork";
 
 interface ContractAddresses {
   resolver: string;
@@ -35,23 +37,33 @@ const networkMetadataToChainId = metadata.networks.reduce((acc, config) => {
   return acc;
 }, {} as { [key: string]: ContractAddresses });
 
+const getNetwork = (chainId: number) => {
+  const network = networksByChainId.get(chainId);
+  if (!network) {
+    throw new Error(`No network found for chainId ${chainId}`);
+  }
+  return network;
+};
+
+findNetworkOrThrow;
+
 const protocolContracts: NetworkContracts = {
-  [1]: networkMetadataToChainId[1],
-  [137]: networkMetadataToChainId[137],
-  [100]: networkMetadataToChainId[100],
-  [10]: networkMetadataToChainId[10],
-  [42161]: networkMetadataToChainId[42161],
-  [5]: networkMetadataToChainId[5],
-  [80001]: networkMetadataToChainId[80001],
-  [43113]: networkMetadataToChainId[43113],
-  [43114]: networkMetadataToChainId[43114],
-  [56]: networkMetadataToChainId[56],
-  [42220]: networkMetadataToChainId[42220],
-  [421613]: networkMetadataToChainId[421613],
-  [420]: networkMetadataToChainId[420],
-  [11155111]: networkMetadataToChainId[11155111],
-  [1442]: networkMetadataToChainId[1442],
-  [84531]: networkMetadataToChainId[84531],
+  [getNetwork(1).slugName]: networkMetadataToChainId[1],
+  [getNetwork(137).slugName]: networkMetadataToChainId[137],
+  [getNetwork(100).slugName]: networkMetadataToChainId[100],
+  [getNetwork(10).slugName]: networkMetadataToChainId[10],
+  [getNetwork(42161).slugName]: networkMetadataToChainId[42161],
+  [getNetwork(5).slugName]: networkMetadataToChainId[5],
+  [getNetwork(80001).slugName]: networkMetadataToChainId[80001],
+  [getNetwork(43113).slugName]: networkMetadataToChainId[43113],
+  [getNetwork(43114).slugName]: networkMetadataToChainId[43114],
+  [getNetwork(56).slugName]: networkMetadataToChainId[56],
+  [getNetwork(42220).slugName]: networkMetadataToChainId[42220],
+  [getNetwork(421613).slugName]: networkMetadataToChainId[421613],
+  [getNetwork(420).slugName]: networkMetadataToChainId[420],
+  [getNetwork(11155111).slugName]: networkMetadataToChainId[11155111],
+  [getNetwork(1442).slugName]: networkMetadataToChainId[1442],
+  [getNetwork(84531).slugName]: networkMetadataToChainId[84531],
 };
 
 export default protocolContracts;

--- a/src/redux/protocolContracts.ts
+++ b/src/redux/protocolContracts.ts
@@ -36,22 +36,22 @@ const networkMetadataToChainId = metadata.networks.reduce((acc, config) => {
 }, {} as { [key: string]: ContractAddresses });
 
 const protocolContracts: NetworkContracts = {
-  "eth-mainnet": networkMetadataToChainId[1],
-  "polygon-mainnet": networkMetadataToChainId[137],
-  "xdai-mainnet": networkMetadataToChainId[100],
-  "optimism-mainnet": networkMetadataToChainId[10],
-  "arbitrum-one": networkMetadataToChainId[42161],
-  "eth-goerli": networkMetadataToChainId[5],
-  "polygon-mumbai": networkMetadataToChainId[80001],
-  "avalanche-fuji": networkMetadataToChainId[43113],
-  "avalanche-c": networkMetadataToChainId[43114],
-  "bsc-mainnet": networkMetadataToChainId[56],
-  "celo-mainnet": networkMetadataToChainId[42220],
-  "arbitrum-goerli": networkMetadataToChainId[421613],
-  "optimism-goerli": networkMetadataToChainId[420],
-  "eth-sepolia": networkMetadataToChainId[11155111],
-  "polygon-zkevm-testnet": networkMetadataToChainId[1442],
-  "base-goerli": networkMetadataToChainId[84531],
+  [1]: networkMetadataToChainId[1],
+  [137]: networkMetadataToChainId[137],
+  [100]: networkMetadataToChainId[100],
+  [10]: networkMetadataToChainId[10],
+  [42161]: networkMetadataToChainId[42161],
+  [5]: networkMetadataToChainId[5],
+  [80001]: networkMetadataToChainId[80001],
+  [43113]: networkMetadataToChainId[43113],
+  [43114]: networkMetadataToChainId[43114],
+  [56]: networkMetadataToChainId[56],
+  [42220]: networkMetadataToChainId[42220],
+  [421613]: networkMetadataToChainId[421613],
+  [420]: networkMetadataToChainId[420],
+  [11155111]: networkMetadataToChainId[11155111],
+  [1442]: networkMetadataToChainId[1442],
+  [84531]: networkMetadataToChainId[84531],
 };
 
 export default protocolContracts;

--- a/src/utils/findNetwork.ts
+++ b/src/utils/findNetwork.ts
@@ -1,0 +1,45 @@
+import { isString } from "lodash";
+import { Network } from "../redux/networks";
+import sfMeta from "@superfluid-finance/metadata";
+
+/**
+ * Tries to find a network by parsing the value as slug/chain-id/canonical-name/etc.
+ */
+export const tryFindNetwork = (
+  networks: Network[],
+  value: unknown
+): Network | undefined => {
+  const asNumber = Number(value);
+  if (isFinite(asNumber)) {
+    return networks.find((x) => x.chainId === asNumber);
+  }
+
+  if (isString(value)) {
+    const valueAsLowerCase = value.toLowerCase();
+
+    const bySlug = networks.find((x) => x.slugName === valueAsLowerCase);
+    if (bySlug) {
+      return bySlug;
+    }
+
+    const byMetadata_chainId =
+      sfMeta.getNetworkByName(valueAsLowerCase)?.chainId ??
+      sfMeta.getNetworkByShortName(valueAsLowerCase)?.chainId;
+    if (byMetadata_chainId) {
+      return networks.find((x) => x.chainId === byMetadata_chainId);
+    }
+  }
+
+  return undefined;
+};
+
+export const findNetworkOrThrow = (
+  networks: Network[],
+  value: unknown
+): Network => {
+  const network = tryFindNetwork(networks, value);
+  if (!network) {
+    throw new Error(`Network ${value} not found. This should never happen.`);
+  }
+  return network;
+};


### PR DESCRIPTION
Should fix the tests that got recently broken by mistaken merge to `master`.

All URLs that take in a network identifier should now support previous slugs, chain IDs, metadata canonical names and also metadata short names.