### PR TITLE
bug fix: fetch token total supply from rpc

### DIFF
--- a/src/pages/[_network]/supertokens/[_id]/index.page.tsx
+++ b/src/pages/[_network]/supertokens/[_id]/index.page.tsx
@@ -77,9 +77,15 @@ const SuperTokenPage: NextPage = () => {
 
   const flowRateConverted = flowRateBigNumber
     ? flowRateBigNumber
-        .mul(streamGranularityInSeconds[streamGranularity])
-        .toString()
+      .mul(streamGranularityInSeconds[streamGranularity])
+      .toString()
     : undefined
+
+
+  const { data: totalSupply } = rpcApi.useTotalSupplyQuery({
+    chainId: network.chainId,
+    tokenAddress: address
+  })
 
   const router = useRouter()
   const { tab } = router.query
@@ -279,7 +285,7 @@ const SuperTokenPage: NextPage = () => {
                     superToken ? (
                       superToken.underlyingAddress ===
                         '0x0000000000000000000000000000000000000000' ||
-                      superToken.underlyingAddress === '0x' ? (
+                        superToken.underlyingAddress === '0x' ? (
                         <>None</>
                       ) : (
                         <Tooltip title="View on blockchain explorer">
@@ -488,8 +494,8 @@ const SuperTokenPage: NextPage = () => {
               data-cy={'total-supply'}
               secondary="Total supply"
               primary={
-                tokenStatistics ? (
-                  <EtherFormatted wei={tokenStatistics.totalSupply} />
+                totalSupply ? (
+                  <EtherFormatted wei={totalSupply} />
                 ) : (
                   <Skeleton sx={{ width: '200px' }} />
                 )

--- a/src/redux/adhocRpcEndpoints.ts
+++ b/src/redux/adhocRpcEndpoints.ts
@@ -1,5 +1,6 @@
 import { Address } from '@superfluid-finance/sdk-core'
 import { getFramework, RpcEndpointBuilder } from '@superfluid-finance/sdk-redux'
+import { SuperToken__factory } from '@superfluid-finance/sdk-core'
 
 export const adhocRpcEndpoints = {
   endpoints: (builder: RpcEndpointBuilder) => ({
@@ -42,6 +43,29 @@ export const adhocRpcEndpoints = {
         {
           type: 'GENERAL',
           id: arg.chainId // TODO(KK): Could be made more specific.
+        }
+      ]
+    }),
+    totalSupply: builder.query<
+      string,
+      { chainId: number; tokenAddress: string }
+    >({
+      queryFn: async ({ chainId, tokenAddress }) => {
+        const framework = await getFramework(chainId)
+
+        const totalSupply = await SuperToken__factory.connect(
+          tokenAddress,
+          framework.settings.provider
+        ).totalSupply()
+
+        return {
+          data: totalSupply.toString()
+        }
+      },
+      providesTags: (_result, _error, arg) => [
+        {
+          type: 'GENERAL',
+          id: arg.chainId
         }
       ]
     })


### PR DESCRIPTION
### Why? What?
For some reason, the total supply is not mapped correctly for all tokens on the Subgraph: https://github.com/superfluid-finance/protocol-monorepo/issues/1815

Token with a buggy total supply (ALEPH): https://console.superfluid.finance/avalanche-c/supertokens/0xc0Fbc4967259786C743361a5885ef49380473dCF?tab=streams

https://snowtrace.io/token/0xc0Fbc4967259786C743361a5885ef49380473dCF?chainId=43114

### How?
So the solution for now can be to map the value from the RPC.