### PR TITLE
feat: make Base the default network

### DIFF
--- a/src/components/Layout/SfAppBar.tsx
+++ b/src/components/Layout/SfAppBar.tsx
@@ -14,7 +14,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
-import { polygon } from '../../redux/networks'
+import { defaultNetwork } from '../../redux/networks'
 import AppLink from '../AppLink/AppLink'
 import SearchBar from '../Search/SearchBar'
 import SearchDialog from '../Search/SearchDialog'
@@ -24,7 +24,7 @@ export const SfAppBar = () => {
   const [searchOpen, setSearchOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const router = useRouter()
-  const { _network = polygon.slugName } = router.query
+  const { _network = defaultNetwork.slugName } = router.query
 
   return (
     <>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -8,11 +8,11 @@ import * as React from 'react'
 
 import AppLink from '../components/AppLink/AppLink'
 import NetworkTabs from '../components/NetworkTabs/NetworkTabs'
-import { networks, polygon } from '../redux/networks'
+import { networks, defaultNetwork } from '../redux/networks'
 import { NetworkStreams } from './NetworkStreams'
 
 const Home: NextPage = () => {
-  const [activeTab, setActiveTab] = React.useState(polygon.slugName)
+  const [activeTab, setActiveTab] = React.useState(defaultNetwork.slugName)
 
   return (
     <>

--- a/src/pages/protocol/index.page.tsx
+++ b/src/pages/protocol/index.page.tsx
@@ -2,11 +2,11 @@ import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
-import { polygon } from '../../redux/networks'
+import { defaultNetwork } from '../../redux/networks'
 
 const ProtocolRedirect: NextPage = () => {
   const router = useRouter()
-  useEffect(() => void router.replace(`/${polygon.slugName}/protocol`), [])
+  useEffect(() => void router.replace(`/${defaultNetwork.slugName}/protocol`), [])
 
   return null
 }

--- a/src/pages/super-tokens.page.tsx
+++ b/src/pages/super-tokens.page.tsx
@@ -2,12 +2,12 @@ import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
-import { polygon } from '../redux/networks'
+import { defaultNetwork } from '../redux/networks'
 
 // redirects the legacy url /super-tokens to the default network specific page
 const SuperTokensLegacyRedirect: NextPage = () => {
   const router = useRouter()
-  useEffect(() => void router.replace(`/${polygon.slugName}/supertokens`), [])
+  useEffect(() => void router.replace(`/${defaultNetwork.slugName}/supertokens`), [])
 
   return null
 }

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -38,32 +38,18 @@ const getSupportsGDA = (chainId: number) => {
 }
 
 export const networks = [
-  // mainnets
   {
-    displayName: 'Ethereum',
-    slugName: 'ethereum',
-    chainId: 1,
+    displayName: 'Base Mainnet',
+    slugName: 'base-mainnet',
     isTestnet: false,
-    supportsGDA: getSupportsGDA(1),
-    rpcUrl: getRpcUrl(1),
-    subgraphUrl: getSubgraphUrl(1),
+    supportsGDA: getSupportsGDA(8453),
+    chainId: 8453,
+    rpcUrl: getRpcUrl(8453),
+    subgraphUrl: getSubgraphUrl(8453),
     getLinkForTransaction: (txHash: string): string =>
-      `https://etherscan.io/tx/${txHash}`,
+      `https://basescan.org/tx/${txHash}`,
     getLinkForAddress: (address: string): string =>
-      `https://etherscan.io/address/${address}`
-  },
-  {
-    displayName: 'Gnosis Chain',
-    slugName: 'xdai',
-    chainId: 100,
-    isTestnet: false,
-    supportsGDA: getSupportsGDA(100),
-    rpcUrl: getRpcUrl(100),
-    subgraphUrl: getSubgraphUrl(100),
-    getLinkForTransaction: (txHash: string): string =>
-      `https://gnosisscan.io/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://gnosisscan.io/address/${address}`
+      `https://basescan.org/address/${address}`
   },
   {
     displayName: 'Polygon',
@@ -105,6 +91,33 @@ export const networks = [
       `https://arbiscan.io/address/${address}`
   },
   {
+    displayName: 'Ethereum',
+    slugName: 'ethereum',
+    chainId: 1,
+    isTestnet: false,
+    supportsGDA: getSupportsGDA(1),
+    rpcUrl: getRpcUrl(1),
+    subgraphUrl: getSubgraphUrl(1),
+    getLinkForTransaction: (txHash: string): string =>
+      `https://etherscan.io/tx/${txHash}`,
+    getLinkForAddress: (address: string): string =>
+      `https://etherscan.io/address/${address}`
+  },
+  {
+    displayName: 'Gnosis Chain',
+    slugName: 'xdai',
+    chainId: 100,
+    isTestnet: false,
+    supportsGDA: getSupportsGDA(100),
+    rpcUrl: getRpcUrl(100),
+    subgraphUrl: getSubgraphUrl(100),
+    getLinkForTransaction: (txHash: string): string =>
+      `https://gnosisscan.io/tx/${txHash}`,
+    getLinkForAddress: (address: string): string =>
+      `https://gnosisscan.io/address/${address}`
+  },
+
+  {
     displayName: 'Avalanche C',
     slugName: 'avalanche-c',
     chainId: 43114,
@@ -142,19 +155,6 @@ export const networks = [
       `https://celoscan.io/tx/${txHash}`,
     getLinkForAddress: (address: string): string =>
       `https://celoscan.io/address/${address}`
-  },
-  {
-    displayName: 'Base Mainnet',
-    slugName: 'base-mainnet',
-    isTestnet: false,
-    supportsGDA: getSupportsGDA(8453),
-    chainId: 8453,
-    rpcUrl: getRpcUrl(8453),
-    subgraphUrl: getSubgraphUrl(8453),
-    getLinkForTransaction: (txHash: string): string =>
-      `https://basescan.org/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://basescan.org/address/${address}`
   },
   {
     displayName: 'Degen Chain',
@@ -247,7 +247,7 @@ export const networksByName = new Map<string, Network>(
 export const networksByChainId = new Map<number, Network>(
   networks.map((x) => [x.chainId, x])
 )
-export const polygon = networksByChainId.get(137)!
+export const defaultNetwork = networksByChainId.get(8453)!
 export const networksByTestAndName = sortBy(
   [(x) => x.isTestnet, (x) => x.slugName],
   networks

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -39,6 +39,19 @@ const getSupportsGDA = (chainId: number) => {
 
 export const networks = [
   {
+    displayName: 'Ethereum',
+    slugName: 'ethereum',
+    chainId: 1,
+    isTestnet: false,
+    supportsGDA: getSupportsGDA(1),
+    rpcUrl: getRpcUrl(1),
+    subgraphUrl: getSubgraphUrl(1),
+    getLinkForTransaction: (txHash: string): string =>
+      `https://etherscan.io/tx/${txHash}`,
+    getLinkForAddress: (address: string): string =>
+      `https://etherscan.io/address/${address}`
+  },
+  {
     displayName: 'Base Mainnet',
     slugName: 'base-mainnet',
     isTestnet: false,
@@ -89,19 +102,6 @@ export const networks = [
       `https://arbiscan.io/tx/${txHash}`,
     getLinkForAddress: (address: string): string =>
       `https://arbiscan.io/address/${address}`
-  },
-  {
-    displayName: 'Ethereum',
-    slugName: 'ethereum',
-    chainId: 1,
-    isTestnet: false,
-    supportsGDA: getSupportsGDA(1),
-    rpcUrl: getRpcUrl(1),
-    subgraphUrl: getSubgraphUrl(1),
-    getLinkForTransaction: (txHash: string): string =>
-      `https://etherscan.io/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://etherscan.io/address/${address}`
   },
   {
     displayName: 'Gnosis Chain',


### PR DESCRIPTION
**Why?**
We're having a ton of volume on Base and would like to better showcase it.

**What?**
Make Base the default network on the frontpage and other pages if network is not specified. Also re-ordered the networks slightly more logically visually.

Slack thread: https://superfluidhq.slack.com/archives/C04UR5SDKHV/p1715705888658979