### PR TITLE
Refactor: Clean up Cypress step definitions without changing structure

### DIFF
--- a/cypress/e2e/IndexPage/IndexPage.ts
+++ b/cypress/e2e/IndexPage/IndexPage.ts
@@ -1,34 +1,44 @@
-import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
-import { CommonElements } from '../../pageObjects/components/CommonElements'
-import { IndexPage } from '../../pageObjects/pages/IndexPage'
-import { LandingPage } from '../../pageObjects/pages/LandingPage'
+import { CommonElements } from '../../pageObjects/components/CommonElements';
+import { IndexPage } from '../../pageObjects/pages/IndexPage';
+import { LandingPage } from '../../pageObjects/pages/LandingPage';
 
-Given(`User has opened the {string} page on {string}`, (page, network) => {
-  LandingPage.openDataPage(page, network)
-})
+/** Opens a data page for a given network.
+ * @param {string} page
+ * @param {string} network
+ */
+Given(
+  'User has opened the {string} page on {string}',
+  (page, network) => LandingPage.openDataPage(page, network)
+);
 
 Then(
-  `Index general information is showing correct data for {string}`,
-  (network) => {
-    IndexPage.validateIndexGeneralInformation(network)
-  }
-)
+  'Index general information is showing correct data for {string}',
+  (network) => IndexPage.validateIndexGeneralInformation(network)
+);
 
-Then(`Index units overview is showing correct data for {string}`, (network) => {
-  IndexPage.validateIndexUnitsOverview(network)
-})
+Then(
+  'Index units overview is showing correct data for {string}',
+  (network) => IndexPage.validateIndexUnitsOverview(network)
+);
 
-Then(`Distributions table is showing correct data for {string}`, (network) => {
-  IndexPage.validateDistributionsTable(network)
-})
+Then(
+  'Distributions table is showing correct data for {string}',
+  (network) => IndexPage.validateDistributionsTable(network)
+);
 
-Then(`Subscriptions table is showing correct data for {string}`, (network) => {
-  IndexPage.validateSubscriptionsTable(network)
-})
-Then(`User opens the first subscription details`, () => {
-  IndexPage.openFirstSubscriptionDetails()
-})
-Then(`Subscription page container is visible`, () => {
-  CommonElements.subscriptionContainerVisible()
-})
+Then(
+  'Subscriptions table is showing correct data for {string}',
+  (network) => IndexPage.validateSubscriptionsTable(network)
+);
+
+Then(
+  'User opens the first subscription details',
+  () => IndexPage.openFirstSubscriptionDetails()
+);
+
+Then(
+  'Subscription page container is visible',
+  () => CommonElements.subscriptionContainerVisible()
+);


### PR DESCRIPTION
This pull request includes a code cleanup of the Cypress Cucumber step definitions. The structure and logic of the steps remain unchanged, but the following improvements were made:

Unified code style (consistent use of semicolons and arrow functions)

Removed unnecessary braces and return statements for one-liners

Improved readability by reducing visual noise

Added inline JSDoc-style comments for better context (optional)

These changes aim to enhance maintainability and readability without altering the behavior or step syntax used in the feature files.