### PR TITLE
Add pool member counts and adjustment flow rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@mui/x-data-grid": "^5.11.1",
     "@reduxjs/toolkit": "^1.8.2",
     "@sentry/nextjs": "^7.120.3",
+    "@sfpro/sdk": "^0.1.9",
     "@socialgouv/matomo-next": "^1.9.2",
     "@superfluid-finance/metadata": "^1.6.0",
     "@superfluid-finance/sdk-core": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^7.120.3
         version: 7.120.3(next@12.3.7(@babel/core@7.23.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.91.0)
+      '@sfpro/sdk':
+        specifier: ^0.1.9
+        version: 0.1.9(@wagmi/core@2.17.3(@tanstack/query-core@5.80.6)(@types/react@18.3.23)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)))(react@18.3.1)(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.15.6(@tanstack/query-core@5.80.6)(@tanstack/react-query@5.80.6(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))
       '@socialgouv/matomo-next':
         specifier: ^1.9.2
         version: 1.9.2(next@12.3.7(@babel/core@7.23.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -2606,6 +2609,23 @@ packages:
   '@sentry/webpack-plugin@1.21.0':
     resolution: {integrity: sha512-x0PYIMWcsTauqxgl7vWUY6sANl+XGKtx7DCVnnY7aOIIlIna0jChTAPANTfA2QrK+VK+4I/4JxatCEZBnXh3Og==}
     engines: {node: '>= 8'}
+
+  '@sfpro/sdk@0.1.9':
+    resolution: {integrity: sha512-VWyGHUMtjh7V8QrBcZrXUHjW2sp3731U4AqJt0C5jMBVcq7guAR05JvZBFfwfHdNwFKyth5Vf2wV5wntWL3ODA==}
+    peerDependencies:
+      '@wagmi/core': ^2
+      react: '>=18'
+      viem: ^2
+      wagmi: ^2
+    peerDependenciesMeta:
+      '@wagmi/core':
+        optional: true
+      react:
+        optional: true
+      viem:
+        optional: true
+      wagmi:
+        optional: true
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -13258,6 +13278,13 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sfpro/sdk@0.1.9(@wagmi/core@2.17.3(@tanstack/query-core@5.80.6)(@types/react@18.3.23)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)))(react@18.3.1)(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.15.6(@tanstack/query-core@5.80.6)(@tanstack/react-query@5.80.6(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))':
+    optionalDependencies:
+      '@wagmi/core': 2.17.3(@tanstack/query-core@5.80.6)(@types/react@18.3.23)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))
+      react: 18.3.1
+      viem: 2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      wagmi: 2.15.6(@tanstack/query-core@5.80.6)(@tanstack/react-query@5.80.6(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(immer@9.0.21)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.31.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+
   '@sideway/address@4.1.5':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -16501,7 +16528,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-react: 7.33.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.1)
@@ -16527,7 +16554,7 @@ snapshots:
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.1
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.10
@@ -16546,7 +16573,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3

--- a/src/pages/[_network]/pools/PoolPageContent.tsx
+++ b/src/pages/[_network]/pools/PoolPageContent.tsx
@@ -20,14 +20,18 @@ import {
   Pool,
   SkipPaging
 } from '@superfluid-finance/sdk-core'
+import { gdaForwarderAbi, gdaForwarderAddress } from '@sfpro/sdk/abi'
 import { gql } from 'graphql-request'
 import Error from 'next/error'
 import { FC, useState } from 'react'
+import { Address } from 'viem'
+import { useReadContract } from 'wagmi'
 
 import AccountAddress from '../../../components/Address/AccountAddress'
 import { AccountAddressFormatted } from '../../../components/Address/AccountAddressFormatted'
 import SuperTokenAddress from '../../../components/Address/SuperTokenAddress'
 import BalanceWithToken from '../../../components/Amount/BalanceWithToken'
+import FlowRate from '../../../components/Amount/FlowRate'
 import FlowingBalanceWithToken from '../../../components/Amount/FlowingBalanceWithToken'
 import AppLink from '../../../components/AppLink/AppLink'
 import CopyLink from '../../../components/Copy/CopyLink'
@@ -57,6 +61,18 @@ export const PoolPageContent: FC<{ id: string; network: Network }> = ({
   })
 
   const pool: Pool | null | undefined = poolQuery.data
+
+  const adjustmentFlowRateQuery = useReadContract({
+    chainId: network.chainId,
+    address:
+      gdaForwarderAddress[
+        network.chainId as keyof typeof gdaForwarderAddress
+      ],
+    abi: gdaForwarderAbi,
+    functionName: 'getPoolAdjustmentFlowRate',
+    args: [id as Address],
+    query: { enabled: Boolean(pool) }
+  })
 
   const [
     instantDistributionUpdatedEventPaging,
@@ -175,6 +191,9 @@ export const PoolPageContent: FC<{ id: string; network: Network }> = ({
                   totalUnits
                   totalConnectedUnits
                   totalDisconnectedUnits
+                  totalMembers
+                  totalConnectedMembers
+                  totalDisconnectedMembers
                 }
               }
             `}
@@ -388,6 +407,74 @@ export const PoolPageContent: FC<{ id: string; network: Network }> = ({
                   </ListItem>
                 </Grid>
               </Grid>
+              <ListItem data-cy={'total-members'} divider>
+                <ListItemText
+                  secondary={
+                    <>
+                      Total Members
+                      <InfoTooltipBtn
+                        dataCy={'total-members-tooltip'}
+                        title="The number of accounts with more than 0 units in this pool."
+                      />
+                    </>
+                  }
+                  primary={
+                    pool ? (
+                      pool.totalMembers
+                    ) : (
+                      <Skeleton sx={{ width: '75px' }} />
+                    )
+                  }
+                />
+              </ListItem>
+              <Grid container>
+                <Grid item xs={6}>
+                  <ListItem divider>
+                    <ListItemText
+                      data-cy="total-connected-members"
+                      secondary={
+                        <>
+                          Total Connected Members
+                          <InfoTooltipBtn
+                            dataCy={'total-connected-members-tooltip'}
+                            title="Members whose balance automatically reflects distributions in real-time."
+                          />
+                        </>
+                      }
+                      primary={
+                        pool ? (
+                          pool.totalConnectedMembers
+                        ) : (
+                          <Skeleton sx={{ width: '75px' }} />
+                        )
+                      }
+                    />
+                  </ListItem>
+                </Grid>
+                <Grid item xs={6}>
+                  <ListItem divider>
+                    <ListItemText
+                      data-cy="total-disconnected-members"
+                      secondary={
+                        <>
+                          Total Disconnected Members
+                          <InfoTooltipBtn
+                            dataCy={'total-disconnected-members-tooltip'}
+                            title="Members who must manually claim their accumulated distributions."
+                          />
+                        </>
+                      }
+                      primary={
+                        pool ? (
+                          pool.totalDisconnectedMembers
+                        ) : (
+                          <Skeleton sx={{ width: '75px' }} />
+                        )
+                      }
+                    />
+                  </ListItem>
+                </Grid>
+              </Grid>
               <ListItem divider data-cy={'total-amount-distributed'}>
                 <ListItemText
                   secondary="Total Amount Distributed"
@@ -457,6 +544,27 @@ export const PoolPageContent: FC<{ id: string; network: Network }> = ({
                   </ListItem>
                 </Grid>
               </Grid>
+              {adjustmentFlowRateQuery.data != null &&
+                adjustmentFlowRateQuery.data !== BigInt(0) && (
+                  <ListItem data-cy={'adjustment-flow-rate'}>
+                    <ListItemText
+                      secondary={
+                        <>
+                          Adjustment Flow Rate
+                          <InfoTooltipBtn
+                            dataCy={'adjustment-flow-rate-tooltip'}
+                            title="The rounding remainder flow directed to the pool admin due to integer division when distributing flows across members. Queried directly from the blockchain for accuracy."
+                          />
+                        </>
+                      }
+                      primary={
+                        <FlowRate
+                          flowRate={adjustmentFlowRateQuery.data.toString()}
+                        />
+                      }
+                    />
+                  </ListItem>
+                )}
             </List>
           </Card>
         </Grid>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "incremental": true,
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "paths": {
+      "@sfpro/sdk/abi": ["./node_modules/@sfpro/sdk/dist/abi/index.d.ts"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- Display total members, connected members, and disconnected members on the pool page (mirroring the existing units breakdown)
- Show the pool adjustment flow rate (queried on-chain via GDA forwarder) when it's non-zero
- Add `@sfpro/sdk` dependency for GDA forwarder ABI and addresses

## Test plan
- [ ] Verify pool page loads without errors
- [ ] Check that total members / connected / disconnected counts render correctly
- [ ] Navigate to a pool with a non-zero adjustment flow rate and verify it displays
- [ ] Confirm pools on all supported networks resolve the GDA forwarder address correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)