### PR TITLE
feat: add base:app_id meta tag to every page

### DIFF
--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -9,6 +9,7 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
+          <meta name="base:app_id" content="6a0eea56ecece1eb393a490f" />
           <link
             rel="stylesheet"
             href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500;700&family=Roboto:wght@300;400;500;700&display=swap"


### PR DESCRIPTION
## Summary
- Add `<meta name="base:app_id" content="6a0eea56ecece1eb393a490f" />` to `_document.page.tsx` so the tag renders in the `<head>` of every page.

## Test plan
- [x] `bun run dev` and view-source on a page — confirm the meta tag is in `<head>`.
- [x] Navigate to a different route and re-check view-source — tag still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)