### PR TITLE
chore: remove discontinued scroll-sepolia network

### DIFF
--- a/src/pages/wagmi.ts
+++ b/src/pages/wagmi.ts
@@ -14,7 +14,6 @@ import {
   optimismSepolia,
   polygon,
   scroll,
-  scrollSepolia,
   sepolia
 } from 'viem/chains' // prolly not a fantastic approach for bundle size
 import { createConfig, http } from 'wagmi'
@@ -36,8 +35,7 @@ const allWagmiChains = [
   avalancheFuji,
   sepolia,
   optimismSepolia,
-  baseSepolia,
-  scrollSepolia
+  baseSepolia
 ] as const
 
 if (allWagmiChains.length !== networks.length) {

--- a/src/redux/networks.ts
+++ b/src/redux/networks.ts
@@ -223,19 +223,6 @@ export const networks = [
       `https://sepolia-optimism.etherscan.io/address/${address}`
   },
   {
-    displayName: 'Scroll Sepolia',
-    slugName: 'scroll-sepolia',
-    isTestnet: true,
-    supportsGDA: getSupportsGDA(534351),
-    chainId: 534351,
-    rpcUrl: getRpcUrl(534351),
-    subgraphUrl: getSubgraphUrl(534351),
-    getLinkForTransaction: (txHash: string): string =>
-      `https://sepolia.scrollscan.com/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://sepolia.scrollscan.com/address/${address}`
-  },
-  {
     displayName: 'Base Sepolia',
     slugName: 'base-sepolia',
     isTestnet: true,


### PR DESCRIPTION
Removes the Scroll Sepolia network (chainId `534351`) from the explorer.

## Why

1. Scroll Sepolia is being **discontinued**.
2. Its canonical Superfluid subgraph alias was serving **Optimism Sepolia** data — the endpoint reported head block `46674627`, which cannot exist on Scroll Sepolia (chain head ~19.0M) and matches Optimism Sepolia's block hash exactly. Reported upstream separately; this PR only removes the network from the explorer.

## Changes

- `src/redux/networks.ts` — removed the `Scroll Sepolia` entry from the `networks` array.
- `src/pages/wagmi.ts` — removed the `scrollSepolia` import from `viem/chains` and its entry from the `allWagmiChains` tuple.

Net: 1 insertion, 16 deletions. A repo-wide grep for `scroll-sepolia` / `scrollSepolia` / `534351` returns no remaining hits.

## Notes for review

- **Scroll mainnet (`534352`) is untouched** — only the Sepolia testnet entry was removed.
- No dangling references: `ChainId`, `SlugName`, `WagmiChainId`, `networksByName`, `networksByChainId` and `networksByTestAndName` are all derived from the two arrays, so they narrowed automatically. No casts were needed.
- `wagmi.ts` throws at module load if `allWagmiChains.length !== networks.length`. Both arrays go 16 → 15 in this commit, so the invariant still holds — worth keeping in mind for any future network removal, since editing only one side breaks app boot.

## Verification

- `tsc --noEmit` — clean, zero errors.
- `next lint` — zero errors; remaining warnings are pre-existing and in untouched files.
- `prettier --check` — both changed files pass. (31 unrelated files fail on `master` as well; left alone.)
- No unit tests exist in this repo — the only suite is Cypress e2e, which needs a running app and live subgraphs. Its fixtures contain no Scroll Sepolia references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)